### PR TITLE
Missing scpred preprocess

### DIFF
--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -380,6 +380,10 @@ tools:
   - name: scpred_predict_labels
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scpred_tools'
+    
+  - name: scpred_preprocess_data
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
 
   - name: scpred_train_model
     owner: ebi-gxa


### PR DESCRIPTION
Another missing module. Can be merged straightaway as it doesn't use a new label.